### PR TITLE
Changed the home page title font color and para color

### DIFF
--- a/src/components/styles/Home.css
+++ b/src/components/styles/Home.css
@@ -20,7 +20,7 @@
   width: 735px;
 }
 .son__Para{
-  color: #663F3F;
+  color: var(--orange);
   ;
 }
 .son__Para h3{
@@ -164,8 +164,8 @@ color: #FFC069;
     max-width: none !important;
     text-align: center !important;
   }
-  .son__Para h3 span{
-    color: #fff;
+  .son__Para h3 span {
+    color: #ffc069;
   }
 }
 


### PR DESCRIPTION
Text  Was Getting  Hidden When Viewed In Mobile Pages Due To Same Font Color As Background 
## changes made 👍 
- changed .son_para colour to orange 
- changed media query at 920px  for .son__Para h3 span to colour : #ffc069;